### PR TITLE
Allow cross-platform access to standard user dirs (Pictures, Videos, ...)

### DIFF
--- a/shinydir.toml
+++ b/shinydir.toml
@@ -16,19 +16,14 @@ hide-ok-directories = true # hide directories (and automove rules) when they are
 
 [dir."$HOME"]
 allowed-dirs = [
-    { name = "Downloads" },
-    { name = "Pictures" },
-    { name = "Desktop" },
-    { name = "Videos" },
-    { name = "Music" },
-    { name = "Documents" },
+    { pattern = "^[A-Z][a-z]*$" }, # allow directories with a capitalized ascii name without whitespaces
     { pattern = "^\\." }, # allow any hidden directory
 ]
 allowed-files = [
     { pattern = "^\\." }, # allow any hidden file
 ]
 
-[dir."$HOME/Videos"]
+[dir."$XDG_VIDEOS_DIR"]
 recursive = true # sub-folders will have the same rules
 recursive-ignore-children = [
     # while performing recursive check, it will ignore these child directories
@@ -40,9 +35,10 @@ allowed-files = [
     { ext = "mp4" },
     { ext = "mov" },
     { ext = "mkv" },
+    { ext = "webm" },
 ]
 
-[dir."$HOME/Music"]
+[dir."$XDG_MUSIC_DIR"] # $XDG_MUSIC_DIR will be replaced with the path to the current user's Music directory
 recursive = true
 allowed-files = [
     { ext = "mp3" },
@@ -51,7 +47,7 @@ allowed-files = [
     { ext = "flac" },
 ]
 
-[dir."$HOME/Downloads"]
+[dir."$XDG_DOWNLOAD_DIR"]
 allowed-dirs = [] # empty 'allowed-dirs' mean no directory is valid
 # no 'allow-files' means any file is valid
 
@@ -82,7 +78,7 @@ force-dry-run = true # force dry run setting
 #     { ext = "mov" },
 #     { ext = "mkv" },
 # ]
-# to = "$HOME/Videos"
+# to = "$XDG_VIDEOS_DIR"
 
 # [[automove.rules]]
 # name = "Home-Music"
@@ -97,12 +93,12 @@ force-dry-run = true # force dry run setting
 
 # [[automove.rules]]
 # name = "Screenshots"
-# parent = "$HOME/Pictures/Screenshots"
+# parent = "$XDG_PICTURES_DIR/Screenshots"
 # match = [
 #     { ext = "png" },
 #     { ext = "jpg" },
 # ]
-# to = "$HOME/Pictures/Screenshots"
+# to = "XDG_PICTURES_DIR/Screenshots"
 # # pass each matched file to the following script that returns placement filename
 # # the script path is relative to the parent directory of this config file
 # # Note: `to` is still required! It will be the base path of any relative filename the script returns.

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ fn main() {
 fn run() -> anyhow::Result<()> {
     let cli: Cli = Cli::parse();
 
+    set_missing_env_vars();
+
     // Read config
     let config_path = find_config_file_path(&cli)?;
 
@@ -86,4 +88,28 @@ fn create_config_file() -> anyhow::Result<PathBuf> {
         eprintln!();
     }
     Ok(file_path)
+}
+
+/// Defines xdg directories environment variables in a cross-platform manner
+fn set_missing_env_vars() {
+    if let Some(dirs) = directories::UserDirs::new() {
+        set_env_var_if_missing("HOME", Some(dirs.home_dir()));
+        set_env_var_if_missing("XDG_HOME_DIR", Some(dirs.home_dir()));
+        set_env_var_if_missing("XDG_DOCUMENTS_DIR", dirs.document_dir());
+        set_env_var_if_missing("XDG_DOWNLOAD_DIR", dirs.download_dir());
+        set_env_var_if_missing("XDG_PICTURES_DIR", dirs.picture_dir());
+        set_env_var_if_missing("XDG_MUSIC_DIR", dirs.audio_dir());
+        set_env_var_if_missing("XDG_VIDEOS_DIR", dirs.video_dir());
+        set_env_var_if_missing("XDG_DESKTOP_DIR", dirs.desktop_dir());
+    } else {
+        eprintln!("No valid home directory path could be retrieved. XDG_*_DIR environment variables won't be accessible.");
+    }
+}
+
+fn set_env_var_if_missing(var_name: &str, value: Option<&Path>) {
+    if let Some(value) = value {
+        if env::var(var_name) == Err(env::VarError::NotPresent) {
+            env::set_var(var_name, value);
+        }
+    }
 }


### PR DESCRIPTION
This allows using XDG directory variables such as
`$XDG_DOCUMENTS_DIR` or `$XDG_DESKTOP_DIR` from the shinydir
configuration file.

The default configuration file was updated to use these variables.

As a result, the default configuration file doesn't
cause shinydir to fail anymore when run on windows or in a
linux environment with a non-english locale.

See
https://www.freedesktop.org/wiki/Software/xdg-user-dirs/
and
https://wiki.archlinux.org/title/XDG_user_directories
